### PR TITLE
chore: promote gow-new-1 to version 0.0.8

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -3,9 +3,11 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: https://hazem-internship.github.io/gow-new-1/
+- name: dev2
+  url: https://hazem-internship.github.io/hazem-internship.github.io/
 releases:
 - chart: dev/gow-new-1
-  version: 0.0.3
+  version: 0.0.8
   name: gow-new-1
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# gow-new-1

## Changes in version 0.0.8

### Chores

* release 0.0.8 (jenkins-x-bot)
* add variables (jenkins-x-bot)
