### PR TITLE
chore: promote gow-new-1 to version 0.0.13

### DIFF
--- a/config-root/namespaces/jx-staging/gow-new-1/gow-new-1-gow-new-1-deploy.yaml
+++ b/config-root/namespaces/jx-staging/gow-new-1/gow-new-1-gow-new-1-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gow-new-1-gow-new-1
   labels:
     draft: draft-app
-    chart: "gow-new-1-0.0.12"
+    chart: "gow-new-1-0.0.13"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'gow-new-1'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: gow-new-1-gow-new-1
       containers:
       - name: gow-new-1
-        image: "ghcr.io/hazem-internship/gow-new-1:0.0.12"
+        image: "ghcr.io/hazem-internship/gow-new-1:0.0.13"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.12
+          value: 0.0.13
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-staging/gow-new-1/gow-new-1-svc.yaml
+++ b/config-root/namespaces/jx-staging/gow-new-1/gow-new-1-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: gow-new-1
   labels:
-    chart: "gow-new-1-0.0.12"
+    chart: "gow-new-1-0.0.13"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'gow-new-1'

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,7 +128,7 @@
 	    <tr>
 	      <td>gow-new-1</td>
 	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> gow-new-1</td>
-	      <td>0.0.12</td>
+	      <td>0.0.13</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -282,14 +282,14 @@
   path: helmfiles/jx-staging/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.12
+    appVersion: 0.0.13
     description: A Helm chart for Kubernetes
-    firstDeployed: "2023-02-15T15:36:46Z"
+    firstDeployed: "2023-02-16T09:46:17Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2023-02-15T15:36:46Z"
+    lastDeployed: "2023-02-16T09:46:17Z"
     name: gow-new-1
     releaseName: gow-new-1
     repositoryName: dev
     repositoryUrl: https://hazem-internship.github.io/gow-new-1/
     resourcePath: config-root/namespaces/jx-staging/gow-new-1
-    version: 0.0.12
+    version: 0.0.13

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://hazem-internship.github.io/gow-new-1/
 releases:
 - chart: dev/gow-new-1
-  version: 0.0.12
+  version: 0.0.13
   name: gow-new-1
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# gow-new-1

## Changes in version 0.0.13

### Chores

* release 0.0.13 (jenkins-x-bot)
* add variables (jenkins-x-bot)
